### PR TITLE
Show Error Message in Exceptions Message

### DIFF
--- a/src/Expression.php
+++ b/src/Expression.php
@@ -606,7 +606,7 @@ class Expression implements \ArrayAccess, \IteratorAggregate, ResultSet
                 $statement->execute();
             } catch (\Exception $e) {
                 $new = new Exception([
-                    'DSQL got Exception when executing this query',
+                    'DSQL got Exception when executing this query: '.$e->getMessage(),
                     'error' => $e->getMessage(),
                     'query' => $this->getDebugQuery(),
                 ]);


### PR DESCRIPTION
If this exception is output by some non-atk output which uses functions like getColorfulText(), the only thing displayed is `DSQL got Exception when executing this query` Thats quite annoying as you have do not get any hint whats wrong.

A good example is phpunit which outputs the Exceptions message. While `DSQL got Exception when executing this query` really is not helpful, `DSQL got Exception when executing this query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'ident' in 'field list'` is.